### PR TITLE
added check for lzo - if exists in resources, install

### DIFF
--- a/actions/hadoop-upgrade
+++ b/actions/hadoop-upgrade
@@ -212,6 +212,16 @@ fi
 # set hadoop.version in unitdata
 chlp unitdata set hadoop.version ${new_hadoop_ver}
 
+if grep hadoop-lzo-${cpu_arch} resources.yaml ; then
+        juju-log "Lzo found for ${cpu_arch}, installing"
+        juju-resources fetch hadoop-lzo-${cpu_arch}
+        if [ ! $? -eq 0 ] ; then
+                action-fail "Failed to fetch hadoop-lzo-${cpu_arch} binary"
+        fi
+        lzo_path=`juju-resources resource_path hadoop-lzo-${cpu_arch}`
+        tar -zxf ${lzo_path} -C /usr/lib/hadoop/
+fi
+
 action-set result="complete"
 juju-log "Hadoop version ${new_hadoop_ver} installed"
 init_procs stop

--- a/actions/hadoop-upgrade
+++ b/actions/hadoop-upgrade
@@ -212,7 +212,7 @@ fi
 # set hadoop.version in unitdata
 chlp unitdata set hadoop.version ${new_hadoop_ver}
 
-if grep hadoop-lzo-${cpu_arch} resources.yaml ; then
+if grep -q hadoop-lzo-${cpu_arch} resources.yaml ; then
         juju-log "Lzo found for ${cpu_arch}, installing"
         juju-resources fetch hadoop-lzo-${cpu_arch}
         if [ ! $? -eq 0 ] ; then


### PR DESCRIPTION
For future/other upgrades, might be an idea to store all 'extra' resources in unitdata, so that they can easily be reinstalled.
